### PR TITLE
several updates for initial IMG v1.8.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Steward: [IMG Node](https://pds-imaging.jpl.nasa.gov/)
 
 Only one LDD source version is kept such that it can be managed by github.
 
-- [1.D.0.0](src)
+- [1.E.0.0](src)
 
 ## Versions
 

--- a/src/PDS4_IMG_IngestLDD.xml
+++ b/src/PDS4_IMG_IngestLDD.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model
-    href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.sch"
+    href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1E00.sch"
     schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
 <!-- PDS4 Local Data Dictionary Extended Ingest File for Imaging Node            -->
-<Ingest_LDD xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd">
+<Ingest_LDD 
+  xmlns="http://pds.nasa.gov/pds4/pds/v1" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1E00.xsd">
   
   <name>Imaging</name>
-  <ldd_version_id>1.7.3.0</ldd_version_id>
-  <full_name>Trent M. Hare (active), P. Geissler, R. Joyner, Jordan Padams, E. Rye, C. De Cesare</full_name>
+  <ldd_version_id>1.8.0.0</ldd_version_id>
+  <dictionary_type>Discipline</dictionary_type>
+  <full_name>Trent Hare</full_name>
   <steward_id>img</steward_id>
   <namespace_id>img</namespace_id>
   <comment> This dictionary contains high level classes and attributes used in imaging and
@@ -65,19 +69,16 @@
     - Added Video class to Commanded_Parameters. (bugfix)
     
     1.7.1.0, T.Hare
-    - Added filter_position_count, https://github.com/pds-data-dictionaries/ldd-img/issues/25
-    - Added GOP_Frames, https://github.com/pds-data-dictionaries/ldd-img/issues/26
-    - Added atmospheric_opacity and atmospheric_opacity_reference, https://github.com/pds-data-dictionaries/ldd-img/issues/27
-    - Added detector_to_image_flip, https://github.com/pds-data-dictionaries/ldd-img/issues/31
-    - Changed Flat_Field_Correction from 0:1 to 0:* (unbounded), https://github.com/pds-data-dictionaries/ldd-img/issues/30
-    - Added Spatial_Filter and Image_Filter classes and 6 new children (*filter_window*), 
-        https://github.com/pds-data-dictionaries/ldd-img/issues/28
-    - Under Video added frame_index and gop_start_index, https://github.com/pds-data-dictionaries/ldd-img/issues/26
-    - Under Sampling added saturated_pixel_count, valid_pixel_count and missing pixel_count attributes,
-        https://github.com/pds-data-dictionaries/ldd-img/issues/8
+    - Added filte
+    - Added GOP_Frames
+    - Added atmospheric_opacity and atmospheric_opacity_reference under Radiometric_Correction class
+    - Added detector_to_image_flip
+    - Changed Flat_Field_Correction from 0:1 to 0:* (unbounded)
+    - Added Spatial_Filter and Image_Filter classes and 6 new children (*filter_window*)
+    - Under Video added frame_index and gop_start_index
+    - Under Sampling added saturated_pixel_count, valid_pixel_count and missing pixel_count attributes
     - Added Image_Mask, Image_Mask_File clases and under mask_type, horizon_mask_elevation attributes.
-        anded new Image_Mask added under both Imaging and Commanded_Parameters classes,
-        https://github.com/pds-data-dictionaries/ldd-img/issues/29
+        anded new Image_Mask added under both Imaging and Commanded_Parameters classes
     - Added mask_transparent_value attribute to Image_Mask_File class
     
     1.7.2.0 P.Geissler
@@ -104,9 +105,21 @@
     - Add exposure_scale_factor, exposure_coadd_count, exposure_readout_count to Exposure
     - Add early_scaling to Companding
     
+    1.8.0.0 T.Hare
+    - Update to PDS IM 1.E.0.0
+    - Added GZIP and LZO to onboard_compression_type enumeration options
+    - Added Optical_Properties class with focel_length, f_number, zoom_position attributes
+    - Added focus_initialization_flag attribute under the Focus class
+    - Updated Subframe class for first_line, first_sample, lines, and samples attributes to have minOccurs=0
+    - Updated img_temperature_value to allow nillable=true
+    - Added auto_exposure_lower_threshold, auto_exposure_lower_limit, auto_exposure_upper_threshold,
+        auto_exposure_upper_limit, auto_exposure_roi_lines, auto_exposure_roi_samples,
+        auto_exposure_roi_first_line, auto_exposure_roi_first_sample attributes to Autoexposure
+    - Added Image_Compression_Segment under JPEG_Parameters class
+    - Renamed attribute bad_pixel_replacement_table to bad_pixel_replacement_table_id and updated definition
 
   </comment>
-  <last_modification_date_time>2020-05-13T17:30:00Z</last_modification_date_time>
+  <last_modification_date_time>2020-08-19T17:30:00Z</last_modification_date_time>
 
 
   <!--                     -->
@@ -212,6 +225,124 @@
   </DD_Attribute>
   
   <DD_Attribute>
+    <name>auto_exposure_lower_threshold</name>
+    <version_id>1.0</version_id>
+    <local_identifier>auto_exposure_lower_threshold</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies the lower threshold DN value for which a specified number of pixels 
+      is permitted to exceed. The auto_exposure_lower_limit defines the number of pixels 
+      allowed to exceed this threshold.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  
+  <DD_Attribute>
+    <name>auto_exposure_lower_limit</name>
+    <version_id>1.0</version_id>
+    <local_identifier>auto_exposure_lower_limit</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies the maximum number of pixels that are allowed to be below 
+      the lower threshold defined by auto_exposure_lower_limit.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_NonNegative_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  
+  <DD_Attribute>
+    <name>auto_exposure_upper_threshold</name>
+    <version_id>1.0</version_id>
+    <local_identifier>auto_exposure_upper_threshold</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies the upper threshold DN value for which a specified number of 
+      pixels is permitted to exceed. The auto_exposure_upper_limit defines the number 
+      of pixels allowed to exceed this threshold.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  
+  <DD_Attribute>
+    <name>auto_exposure_upper_limit</name>
+    <version_id>1.0</version_id>
+    <local_identifier>auto_exposure_upper_limit</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies the maximum number of pixels that are allowed to be above 
+      the upper threshold defined by auto_exposure_upper_limit.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_NonNegative_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  
+  <DD_Attribute>
+    <name>auto_exposure_roi_lines</name>
+    <version_id>1.0</version_id>
+    <local_identifier>auto_exposure_roi_lines</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies the number of lines in the autoexposure region of interest.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_NonNegative_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  
+  <DD_Attribute>
+    <name>auto_exposure_roi_samples</name>
+    <version_id>1.0</version_id>
+    <local_identifier>auto_exposure_roi_samples</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies the number of samples in the autoexposure region of interest.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_NonNegative_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  
+  <DD_Attribute>
+    <name>auto_exposure_roi_first_line</name>
+    <version_id>1.0</version_id>
+    <local_identifier>auto_exposure_roi_first_line</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies the (1-based) starting line for the autoexposure region of interest.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_NonNegative_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  
+  <DD_Attribute>
+    <name>auto_exposure_roi_first_sample</name>
+    <version_id>1.0</version_id>
+    <local_identifier>auto_exposure_roi_first_sample</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies the (1-based) starting sample for the autoexposure region of interest.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_NonNegative_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+  
+  <DD_Attribute>
     <name>autofocus_step_count</name>
     <version_id>1.0</version_id>
     <local_identifier>autofocus_step_count</local_identifier>
@@ -248,7 +379,7 @@
     <nillable_flag>false</nillable_flag>
     <submitter_name>Trent Hare</submitter_name>
     <definition>If true, specifies whether or not bad pixel replacement processing was requested or completed.
-      See bad_pixel_replacement_table.</definition>
+      See bad_pixel_replacement_table_id.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Boolean</value_data_type>
@@ -257,13 +388,13 @@
   </DD_Attribute>
 
   <DD_Attribute>
-    <name>bad_pixel_replacement_table</name>
+    <name>bad_pixel_replacement_table_id</name>
     <version_id>1.0</version_id>
-    <local_identifier>bad_pixel_replacement_table</local_identifier>
+    <local_identifier>bad_pixel_replacement_table_id</local_identifier>
     <nillable_flag>false</nillable_flag>
     <submitter_name>Trent Hare</submitter_name>
-    <definition>Specfies the table number of the bad pixel table used in the bad pixel replacement process. 
-      See also bad_pixel_replacement_flag.</definition>
+    <definition>Specifies the table used to replace bad pixels. A bad pixel table typically lists the location 
+      of each bad pixel on a detector. The specific table used is mission-specific.</definition>
     <DD_Value_Domain>
       <enumeration_flag>false</enumeration_flag>
       <value_data_type>ASCII_Short_String_Collapsed</value_data_type>
@@ -1325,6 +1456,48 @@
       <unit_of_measure_type>Units_of_None</unit_of_measure_type>
     </DD_Value_Domain>
   </DD_Attribute>
+
+  <DD_Attribute>
+    <name>focus_initialization_flag</name>
+    <version_id>1.0</version_id>
+    <local_identifier>focus_initialization_flag</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Specifies whether the instrument focus mechanism should be (or was) initialized before use.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Boolean</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+
+  <DD_Attribute>
+    <name>focal_length</name>
+    <version_id>1.0</version_id>
+    <local_identifier>focal_length</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Defines the focal length of the optics used in acquiring the image.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Real</value_data_type>
+      <unit_of_measure_type>Units_of_Length</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+
+  <DD_Attribute>
+    <name>f_number</name>
+    <version_id>1.0</version_id>
+    <local_identifier>f_number</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Defines the f/number for the optics used in acquiring the image.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Real</value_data_type>
+      <unit_of_measure_type>Units_of_Length</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
   
   <DD_Attribute>
     <name>frame_count</name>
@@ -1356,7 +1529,23 @@
       <unit_of_measure_type>Units_of_None</unit_of_measure_type>
     </DD_Value_Domain>
   </DD_Attribute>
-  
+
+  <DD_Attribute>
+    <name>frame_index</name>
+    <version_id>1.0</version_id>
+    <local_identifier>frame_index</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>The frame_index attribute specifies the sequence number of this frame in 
+      the context of the entire video, i.e. the first frame of the video would be 
+      index 1, up to frame_count.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_NonNegative_Integer</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+
   <DD_Attribute>
     <name>frame_interval</name>
     <version_id>1.0</version_id>
@@ -1370,7 +1559,7 @@
       <unit_of_measure_type>Units_of_Time</unit_of_measure_type>
     </DD_Value_Domain>
   </DD_Attribute>
-  
+
   <DD_Attribute>
     <name>frame_rate</name>
     <version_id>1.0</version_id>
@@ -1495,22 +1684,6 @@
     </DD_Value_Domain>
   </DD_Attribute>
   
-  <DD_Attribute>
-    <name>frame_index</name>
-    <version_id>1.0</version_id>
-    <local_identifier>frame_index</local_identifier>
-    <nillable_flag>false</nillable_flag>
-    <submitter_name>Trent Hare</submitter_name>
-    <definition>The frame_index attribute specifies the sequence number of this frame in 
-      the context of the entire video, i.e. the first frame of the video would be 
-      index 1, up to frame_count.</definition>
-    <DD_Value_Domain>
-      <enumeration_flag>false</enumeration_flag>
-      <value_data_type>ASCII_NonNegative_Integer</value_data_type>
-      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
-    </DD_Value_Domain>
-  </DD_Attribute>
-
   <DD_Attribute>
     <name>height_pixels</name>
     <version_id>1.0</version_id>
@@ -1878,14 +2051,18 @@
     <nillable_flag>false</nillable_flag>
     <submitter_name>Elizabeth D. Rye</submitter_name>
     <definition>The onboard_compression_type attribute identifies the type of on-board
-      compression used for data storage and transmission. Valid Values: 'ICER', 
-      'LOCO', 'JPEG', 'JPEG Progressive', 'MSSS Lossless', 'None'.</definition>
+      compression used for data storage and transmission. Valid Values: 'GZIP', 'ICER', 
+      'LOCO', 'LZO', 'JPEG', 'JPEG Progressive', 'MSSS Lossless', 'None'.</definition>
     <DD_Value_Domain>
       <enumeration_flag>true</enumeration_flag>
       <value_data_type>ASCII_Short_String_Collapsed</value_data_type>
       <minimum_characters>1</minimum_characters>
       <maximum_characters>255</maximum_characters>
       <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+      <DD_Permissible_Value>
+        <value>GZIP</value>
+        <value_meaning>GNU Gzip lossless compression using Lempel-Ziv coding (LZ77)</value_meaning>
+      </DD_Permissible_Value>
       <DD_Permissible_Value>
         <value>ICER</value>
         <value_meaning>ICER Adaptive Variable-Length Coding (ICER)</value_meaning>
@@ -1897,6 +2074,10 @@
       <DD_Permissible_Value>
         <value>LOCO</value>
         <value_meaning>Low-Complexity Lossless Compression</value_meaning>
+      </DD_Permissible_Value>
+      <DD_Permissible_Value>
+        <value>LZO</value>
+        <value_meaning>Lempel-Ziv-Oberhumer, a type of lossless data compression focused on decompression speed.</value_meaning>
       </DD_Permissible_Value>
       <DD_Permissible_Value>
         <value>JPEG</value>
@@ -2170,7 +2351,26 @@
       </DD_Permissible_Value>
     </DD_Value_Domain>
   </DD_Attribute>
-  
+
+  <DD_Attribute>
+    <name>product_flag</name>
+    <version_id>1.0</version_id>
+    <local_identifier>product_flag</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>Indicates whether the product in the enclosing class was requested for downlink
+      (when in Commanded_Parameters), or whether this product actually is the type in question
+      (when in Imaging). For example, Commanded_Parameters.Histogram.product_flag = true indicates 
+      that a histogram was requested as part of the command that created the data product being 
+      labeled, while Imaging.Histogram.product_flag = true indicates that this data product itself 
+      is (or contains) a histogram.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Boolean</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+    
   <DD_Attribute>
     <name>progressive_stage</name>
     <version_id>1.0</version_id>
@@ -2865,7 +3065,7 @@
     <name>temperature_value</name>
     <version_id>1.0</version_id>
     <local_identifier>temperature_value</local_identifier>
-    <nillable_flag>false</nillable_flag>
+    <nillable_flag>true</nillable_flag>
     <submitter_name>Elizabeth D. Rye</submitter_name>
     <definition>The temperature_value attribute provides the temperature, in the specified
       units, of some point on an imaging instrument or other imaging instrument device.</definition>
@@ -3094,6 +3294,23 @@
     </DD_Value_Domain>
   </DD_Attribute>
   
+  <DD_Attribute>
+    <name>zoom_position</name>
+    <version_id>1.0</version_id>
+    <local_identifier>zoom_position</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>The zoom_position attribute defined, in a camera-specific way, the zoom 
+      metric that should be used for geometric processing of the data (e.g. for 
+      creating camera models). This will often be the zoom motor count.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Real</value_data_type>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+
+  
   <!--                   -->
   <!-- Attributes: END   -->
   <!--                   -->
@@ -3292,6 +3509,54 @@
     </DD_Association>
     <DD_Association>
       <identifier_reference>auto_exposure_pixel_fraction</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>auto_exposure_lower_threshold</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>auto_exposure_lower_limit</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>auto_exposure_upper_threshold</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>auto_exposure_upper_limit</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>auto_exposure_roi_lines</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>auto_exposure_roi_samples</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>auto_exposure_roi_first_line</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>auto_exposure_roi_first_sample</identifier_reference>
       <reference_type>attribute_of</reference_type>
       <minimum_occurrences>0</minimum_occurrences>
       <maximum_occurrences>1</maximum_occurrences>
@@ -4125,7 +4390,7 @@
   <!-- Class: Detector -->
   <DD_Class>
     <name>Detector</name>
-    <version_id>1.2</version_id>
+    <version_id>1.3</version_id>
     <local_identifier>Detector</local_identifier>
     <submitter_name>Cristina De Cesare</submitter_name>
     <definition>The Detectorclass contains attributes describing the state of the
@@ -4210,7 +4475,7 @@
       <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
-      <identifier_reference>bad_pixel_replacement_table</identifier_reference>
+      <identifier_reference>bad_pixel_replacement_table_id</identifier_reference>
       <reference_type>attribute_of</reference_type>
       <minimum_occurrences>0</minimum_occurrences>
       <maximum_occurrences>1</maximum_occurrences>
@@ -4693,7 +4958,7 @@
   <!-- Class: Focus  -->
   <DD_Class>
     <name>Focus</name>
-    <version_id>1.1</version_id>
+    <version_id>1.2</version_id>
     <local_identifier>Focus</local_identifier>
     <submitter_name>Cristina De Cesare</submitter_name>
     <definition>The Focus class contains attributes that describe the focus or
@@ -4756,6 +5021,12 @@
       <minimum_occurrences>0</minimum_occurrences>
       <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
+    <DD_Association>
+      <identifier_reference>focus_initialization_flag</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
   </DD_Class>
   
   <!-- Class: Focus_Stack  -->
@@ -4805,13 +5076,13 @@
   <!-- Class: Frame -->
   <DD_Class>
     <name>Frame</name>
-    <version_id>1.0</version_id>
+    <version_id>1.1</version_id>
     <local_identifier>Frame</local_identifier>
     <submitter_name>Jordan Padams</submitter_name>
     <definition>The Frame class contains attributes providing information specific to 
         an image frame. A frame consists of a sequence of measurements made over a specified time 
-        interval, and may include measurements from different 
-        instrument modes.</definition>
+        interval, and may include measurements from different instrument modes. In the 
+        context of Frame, product_flag refers to the actual image.</definition>
     <abstract_flag>false</abstract_flag>
     <element_flag>false</element_flag>
     <DD_Association>
@@ -4822,6 +5093,12 @@
     </DD_Association>
     <DD_Association>
         <identifier_reference>frame_type_name</identifier_reference>
+        <reference_type>attribute_of</reference_type>
+        <minimum_occurrences>0</minimum_occurrences>
+        <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+        <identifier_reference>product_flag</identifier_reference>
         <reference_type>attribute_of</reference_type>
         <minimum_occurrences>0</minimum_occurrences>
         <maximum_occurrences>1</maximum_occurrences>
@@ -5050,6 +5327,12 @@
         <minimum_occurrences>0</minimum_occurrences>
         <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
+    <DD_Association>
+        <identifier_reference>Image_Compression_Segment</identifier_reference>
+        <reference_type>component_of</reference_type>
+        <minimum_occurrences>0</minimum_occurrences>
+        <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
   </DD_Class>
   
   <!-- Class: JPEG_Progressive_Parameters -->
@@ -5231,6 +5514,35 @@
       <identifier_reference>responsivity_factor_b</identifier_reference>
       <reference_type>attribute_of</reference_type>
       <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+  </DD_Class>
+  
+  <!-- Class: Optical_Properties -->
+  <DD_Class>
+    <name>Optical_Properties</name>
+    <version_id>1.0</version_id>
+    <local_identifier>Optical_Properties</local_identifier>
+    <submitter_name>Trent Hare</submitter_name>
+    <definition>The Optical_Properties class describes properties of the optics used in acquiring the image.</definition>
+    <abstract_flag>false</abstract_flag>
+    <element_flag>false</element_flag>
+    <DD_Association>
+      <identifier_reference>focal_length</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>f_number</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>zoom_position</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>0</minimum_occurrences>
       <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
   </DD_Class>
@@ -5600,25 +5912,25 @@
     <DD_Association>
         <identifier_reference>first_line</identifier_reference>
         <reference_type>attribute_of</reference_type>
-        <minimum_occurrences>1</minimum_occurrences>
+        <minimum_occurrences>0</minimum_occurrences>
         <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
         <identifier_reference>first_sample</identifier_reference>
         <reference_type>attribute_of</reference_type>
-        <minimum_occurrences>1</minimum_occurrences>
+        <minimum_occurrences>0</minimum_occurrences>
         <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
         <identifier_reference>lines</identifier_reference>
         <reference_type>attribute_of</reference_type>
-        <minimum_occurrences>1</minimum_occurrences>
+        <minimum_occurrences>0</minimum_occurrences>
         <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
         <identifier_reference>samples</identifier_reference>
         <reference_type>attribute_of</reference_type>
-        <minimum_occurrences>1</minimum_occurrences>
+        <minimum_occurrences>0</minimum_occurrences>
         <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
@@ -5647,6 +5959,35 @@
     </DD_Association>
     <DD_Association>
         <identifier_reference>subframe_type</identifier_reference>
+        <reference_type>attribute_of</reference_type>
+        <minimum_occurrences>0</minimum_occurrences>
+        <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+  </DD_Class>
+
+  <!-- Class: Thumbnail -->
+  <DD_Class>
+    <name>Thumbnail</name>
+    <version_id>1.0</version_id>
+    <local_identifier>Thumbnail</local_identifier>
+    <submitter_name>Jordan Padams</submitter_name>
+    <definition>Describes a Thumbnail product, which is a greatly reduced resolution version of the image.</definition>
+    <abstract_flag>false</abstract_flag>
+    <element_flag>false</element_flag>
+    <DD_Association>
+        <identifier_reference>frame_id</identifier_reference>
+        <reference_type>attribute_of</reference_type>
+        <minimum_occurrences>0</minimum_occurrences>
+        <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+        <identifier_reference>frame_type_name</identifier_reference>
+        <reference_type>attribute_of</reference_type>
+        <minimum_occurrences>0</minimum_occurrences>
+        <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+        <identifier_reference>product_flag</identifier_reference>
         <reference_type>attribute_of</reference_type>
         <minimum_occurrences>0</minimum_occurrences>
         <maximum_occurrences>1</maximum_occurrences>


### PR DESCRIPTION
## Summary
* Update to PDS IM 1.E.0.0
* Added GZIP and LZO to onboard_compression_type enumeration options
* Added Optical_Properties class with focel_length, f_number, zoom_position attributes
* Added focus_initialization_flag attribute under the Focus class
* Updated Subframe class for first_line, first_sample, lines, and samples attributes to have minOccurs=0
* Updated img_temperature_value to allow nillable=true
* Added auto_exposure_lower_threshold, auto_exposure_lower_limit, auto_exposure_upper_threshold,
        auto_exposure_upper_limit, auto_exposure_roi_lines, auto_exposure_roi_samples,
        auto_exposure_roi_first_line, auto_exposure_roi_first_sample attributes to Autoexposure
* Added Image_Compression_Segment under JPEG_Parameters class
* Renamed attribute bad_pixel_replacement_table to bad_pixel_replacement_table_id and updated definition


## Related Issues covered:

* https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues/56
* https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues/53
* https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues/50
* https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues/29
* https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues/28
* https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues/26
* https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues/25
* https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues/23